### PR TITLE
Do not rely on Google's automated generated classes

### DIFF
--- a/dictionary.js
+++ b/dictionary.js
@@ -66,7 +66,7 @@
             var word = document.querySelectorAll("[data-dobid='hdw']")[0].textContent;
             var meaning = "";
 
-            document.querySelector(".PNlCoe [data-dobid='dfn']").querySelectorAll("span").forEach(function(span){
+            document.querySelector("[data-dobid='dfn']").querySelectorAll("span").forEach(function(span){
             	if(!span.querySelector("sup"))
              		meaning = meaning + span.textContent;
             })


### PR DESCRIPTION
Fixes #5 

We're relying on Google's automated generated class names for getting explanation text.

These classes (`.PNlCoe`) are never a reliable thing, and I just noticed that looking for `data-dobid=dfn` itself is enough, as we just need to take the first explanation.