### PR TITLE
Flip popup to left when it overflows out of window

### DIFF
--- a/dictionary.js
+++ b/dictionary.js
@@ -46,7 +46,8 @@
             left: left,
             word: word,
             clientY: event.clientY,
-            height: boundingRect.height
+            height: boundingRect.height,
+            width: boundingRect.width
         };
 
       return toReturn;
@@ -125,6 +126,7 @@
         var style = document.createElement("style");
         //style.textContent = "*{ all: initial}";
         style.textContent = ".mwe-popups{background:#fff;position:absolute;z-index:110;-webkit-box-shadow:0 30px 90px -20px rgba(0,0,0,0.3),0 0 1px #a2a9b1;box-shadow:0 30px 90px -20px rgba(0,0,0,0.3),0 0 1px #a2a9b1;padding:0;font-size:14px;min-width:300px;border-radius:2px}.mwe-popups.mwe-popups-is-not-tall{width:320px}.mwe-popups .mwe-popups-container{color:#222;margin-top:-9px;padding-top:9px;text-decoration:none}.mwe-popups.mwe-popups-is-not-tall .mwe-popups-extract{min-height:40px;max-height:140px;overflow:hidden;margin-bottom:47px;padding-bottom:0}.mwe-popups .mwe-popups-extract{margin:16px;display:block;color:#222;text-decoration:none;position:relative} .mwe-popups.flipped_y:before{content:'';position:absolute;border:8px solid transparent;border-bottom:0;border-top: 8px solid #a2a9b1;bottom:-8px;left:10px}.mwe-popups.flipped_y:after{content:'';position:absolute;border:11px solid transparent;border-bottom:0;border-top:11px solid #fff;bottom:-7px;left:7px} .mwe-popups.mwe-popups-no-image-tri:before{content:'';position:absolute;border:8px solid transparent;border-top:0;border-bottom: 8px solid #a2a9b1;top:-8px;left:10px}.mwe-popups.mwe-popups-no-image-tri:after{content:'';position:absolute;border:11px solid transparent;border-top:0;border-bottom:11px solid #fff;top:-7px;left:7px} .audio{background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAcUlEQVQ4y2P4//8/AyUYQhAH3gNxA7IAIQPmo/H3g/QA8XkgFiBkwHyoYnRQABVfj88AmGZcTuuHyjlgMwBZM7IE3NlQGhQe65EN+I8Dw8MLGgYoFpFqADK/YUAMwOsFigORatFIlYRElaRMWmaiBAMAp0n+3U0kqkAAAAAASUVORK5CYII=);background-position: center;background-repeat: no-repeat;cursor:pointer;margin-left: 8px;opacity: 0.5; width: 16px; display: inline-block;} .audio:hover {opacity: 1;}";
+        style.textContent += ".mwe-popups.flipped_x:before{left:unset;right:10px;}.mwe-popups.flipped_x:after{left:unset;right:7px;}"
         shadow.appendChild(style);
 
         var encapsulateDiv = document.createElement("div");
@@ -184,6 +186,17 @@
             hostDiv.style.top = info.top - 10 - popupDiv.clientHeight + "px";
             if(info.height == 0){
                 hostDiv.style.top = parseInt(hostDiv.style.top) - 8 + "px";
+            }
+        }
+
+        if (info.left + popupDiv.clientWidth > window.innerWidth) {
+            if (window.innerWidth >= popupDiv.clientWidth) {
+                /* Flip to left only if window's width is more than
+                 * popupDiv's width. Otherwise, leave it to right side
+                 * so that it can be scrollable on narrow windows.
+                */
+                popupDiv.className += " flipped_x";
+                hostDiv.style.left = info.left - popupDiv.clientWidth + info.width + 10 + "px";
             }
         }
 


### PR DESCRIPTION
Currently, when the popup overflows from the window, one needs to scroll to right to bring it into view. This commit flips is to left in those cases. 

Also, seems to be a decent fix for #2. 