### PR TITLE
Added ZIndex property to fix div hidden

### DIFF
--- a/content_scripts/dictionary.js
+++ b/content_scripts/dictionary.js
@@ -63,7 +63,7 @@
         hostDiv.className = "dictionaryDiv";
         hostDiv.style.left = info.left -10 + "px";
         hostDiv.style.position = "absolute";
-        hostDiv.stye.zIndex = "10000"
+        hostDiv.stye.zIndex = "1000000"
         hostDiv.attachShadow({mode: 'open'});
 
         var shadow = hostDiv.shadowRoot;

--- a/content_scripts/dictionary.js
+++ b/content_scripts/dictionary.js
@@ -63,6 +63,7 @@
         hostDiv.className = "dictionaryDiv";
         hostDiv.style.left = info.left -10 + "px";
         hostDiv.style.position = "absolute";
+        hostDiv.stye.zIndex = "10000"
         hostDiv.attachShadow({mode: 'open'});
 
         var shadow = hostDiv.shadowRoot;


### PR DESCRIPTION
I added a Z-Index property to fix a problem in some websites where the div that contains the word information is hidden. 
For example, in the Google Assistant Documentation, the div that contains the word information is under the information because of the z-index.