### PR TITLE
fix: add UA to get a parsable result on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dictionary Anywhere
+# Dictionary Anywhere for Android
 The **Dictionary Anywhere** extension helps you stay focused on what you are reading by eliminating the need to search for meaning, 
 Double-clicking any word will view its definition in a small pop-up bubble. 
 Now you never have to leave what you are reading to search for the meaning of the words you don't yet know.

--- a/background/background.js
+++ b/background/background.js
@@ -8,7 +8,12 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const { word, lang } = request, 
         url = `https://www.google.com/search?hl=${lang}&q=define+${word}&gl=US`;
     
+    let headers = new Headers({
+                "User-Agent"   : "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0"
+     });
+    
     fetch(url, { 
+            headers, 
             method: 'GET',
             credentials: 'omit'
         })


### PR DESCRIPTION
The googles translation endpoint seems to reply with different data depending on the UserAgent which the fetch requests sends out. On Android devices this causes all Requests to be unparsable by the followup process and causes the `Sorry. No definition found.` message to always be show. 

By simply setting the UA to a fixed string meant for a Desktop version, everything should work as expected. 

Future Improvement:  might be a good idea to somehow get the latest firefox desktop version from ftp.mozilla.org or somewhere else and use that to to dynamically build the UA string. 