### PR TITLE
Fixes #81 - Look-ups always have "Sorry no definition found"

### DIFF
--- a/content_scripts/dictionary.js
+++ b/content_scripts/dictionary.js
@@ -108,7 +108,7 @@
         audio.style.display = "none";
 
         var moreInfo =document.createElement("a");
-        moreInfo.href = `https://www.google.com/search?hl=${LANGUAGE}&q=define+${info.word}`;
+        moreInfo.href = `https://duckduckgo.com/?q=define+${info.word}`;
         moreInfo.style = "float: right; text-decoration: none;"
         moreInfo.target = "_blank";
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "manifest_version": 2,
   "name": "Dictionary Anywhere",
-  "version": "1.1.0",
+  "version": "1.1.1",
 
   "description": "View definitions easily as you browse the web. Double-click any word to view its definition in a small pop-up bubble.",
 
@@ -40,6 +40,6 @@
 
   "permissions": [
     "storage",
-    "https://www.google.com/"
+    "https://api.dictionaryapi.dev/api/v2/entries/en/"
   ]
 }


### PR DESCRIPTION
Replacing Google with https://dictionaryapi.dev/.

Root cause:

This extension works based on DOM parsing of Google search HTML response of "define $word".

Recently, Google search result page has undergone major change due to AI integration.
This has broken this add-on.

Due to AI integration, other search result page parsing seems volatile.
Better alternative to use dictionaryapi.dev, which is free and from @meetDeveloper. :)

Fixes #81 

Reviewer @meetDeveloper 
